### PR TITLE
Add complex multiplier HLS component

### DIFF
--- a/ComplexMultiplier/.gitignore
+++ b/ComplexMultiplier/.gitignore
@@ -1,0 +1,21 @@
+# Ignore build output directory
+/build
+/export
+
+# Ignore object files and dependent files
+.o
+.d
+
+#Ignore logs folder and log files
+/logs
+.log
+
+#Ignore lock files
+.lock
+
+.bin
+.pdi
+.vitisWorkspace.json
+
+_ide/logs
+_ide/.wsdata

--- a/ComplexMultiplier/compile_commands.json
+++ b/ComplexMultiplier/compile_commands.json
@@ -1,0 +1,27 @@
+[
+  {
+    "directory": "C:\\DTI_work_space\\ComplexMultiplier",
+    "arguments": [
+      "C:\\Xilinx\\2025.1\\Vitis\\vcxx\\libexec\\clang++.exe",
+      "--sysroot=C:\\Xilinx\\2025.1\\Vitis\\tps\\mingw\\10.0.0\\win64.o\\nt",
+      "-fhls",
+      "-hls-syn-headers-dir=C:\\Xilinx\\2025.1\\Vitis\\common\\technology\\autopilot",
+      "-fhlstoplevel=complex_mul",
+      "-c",
+      "C:\\DTI_work_space\\ComplexMultiplier\\.\\complex_mul.cpp"
+    ],
+    "file": "C:\\DTI_work_space\\ComplexMultiplier\\.\\complex_mul.cpp"
+  },
+  {
+    "directory": "C:\\DTI_work_space\\ComplexMultiplier",
+    "arguments": [
+      "C:\\Xilinx\\2025.1\\Vitis\\vcxx\\libexec\\clang++.exe",
+      "--sysroot=C:\\Xilinx\\2025.1\\Vitis\\tps\\mingw\\10.0.0\\win64.o\\nt",
+      "-fhls-tb",
+      "-hls-sim-headers-dir=C:\\Xilinx\\2025.1\\Vitis\\include",
+      "-c",
+      "C:\\DTI_work_space\\ComplexMultiplier\\.\\complex_mul_tb.cpp"
+    ],
+    "file": "C:\\DTI_work_space\\ComplexMultiplier\\.\\complex_mul_tb.cpp"
+  }
+]

--- a/ComplexMultiplier/complex_mul.cpp
+++ b/ComplexMultiplier/complex_mul.cpp
@@ -1,0 +1,22 @@
+#include "complex_mul.h"
+
+void complex_mul(data_t a_real,
+                 data_t a_imag,
+                 data_t b_real,
+                 data_t b_imag,
+                 data_t &c_real,
+                 data_t &c_imag) {
+#pragma HLS INTERFACE s_axilite port=return bundle=CTRL
+#pragma HLS INTERFACE s_axilite port=a_real bundle=CTRL
+#pragma HLS INTERFACE s_axilite port=a_imag bundle=CTRL
+#pragma HLS INTERFACE s_axilite port=b_real bundle=CTRL
+#pragma HLS INTERFACE s_axilite port=b_imag bundle=CTRL
+#pragma HLS INTERFACE s_axilite port=c_real bundle=CTRL
+#pragma HLS INTERFACE s_axilite port=c_imag bundle=CTRL
+
+    complex_t a(a_real, a_imag);
+    complex_t b(b_real, b_imag);
+    complex_t c = a * b;
+    c_real = c.real();
+    c_imag = c.imag();
+}

--- a/ComplexMultiplier/complex_mul.h
+++ b/ComplexMultiplier/complex_mul.h
@@ -1,0 +1,23 @@
+#ifndef COMPLEX_MUL_H
+#define COMPLEX_MUL_H
+
+#if __has_include(<hls_x_complex.h>)
+#  include <hls_x_complex.h>
+#else
+#  include "hls_stub.h"
+#endif
+
+#include <cmath>
+
+using data_t = float;
+using complex_t = hls::x_complex<data_t>;
+
+// Multiply two complex numbers (a_real + j*a_imag) * (b_real + j*b_imag).
+void complex_mul(data_t a_real,
+                 data_t a_imag,
+                 data_t b_real,
+                 data_t b_imag,
+                 data_t &c_real,
+                 data_t &c_imag);
+
+#endif // COMPLEX_MUL_H

--- a/ComplexMultiplier/complex_mul_tb.cpp
+++ b/ComplexMultiplier/complex_mul_tb.cpp
@@ -1,0 +1,18 @@
+#include "complex_mul.h"
+#include <iostream>
+
+int main() {
+    data_t cr = 0.0f;
+    data_t ci = 0.0f;
+    complex_mul(3.0f, 2.0f, -5.0f, 4.0f, cr, ci);
+    const data_t expected_r = -23.0f;
+    const data_t expected_i = 2.0f;
+    const data_t tol = 1e-5f;
+    bool ok = (std::fabs(cr - expected_r) <= tol) && (std::fabs(ci - expected_i) <= tol);
+    if (!ok) {
+        std::cerr << "Mismatch: got (" << cr << ", " << ci << ")";
+        std::cerr << " expected (" << expected_r << ", " << expected_i << ")\n";
+        return 1;
+    }
+    return 0;
+}

--- a/ComplexMultiplier/hls_config.cfg
+++ b/ComplexMultiplier/hls_config.cfg
@@ -1,0 +1,19 @@
+part=xck26-sfvc784-2LV-c
+
+[hls]
+flow_target=vivado
+package.output.format=ip_catalog
+package.output.syn=false
+clock=200Mhz
+clock_uncertainty=10%
+syn.top=complex_mul
+syn.file=./hls_stub.h
+syn.file=./complex_mul.cpp
+syn.file=./complex_mul.h
+tb.file=./complex_mul_tb.cpp
+csim.clean=1
+package.ip.vendor=fotonica109
+package.ip.version=1.0
+package.ip.description=complex multiplier
+package.ip.display_name=Complex_Multiplier
+package.output.file=C:\Vws25\custom_ip_library\complex_multiplier

--- a/ComplexMultiplier/hls_stub.h
+++ b/ComplexMultiplier/hls_stub.h
@@ -1,0 +1,32 @@
+// hls_stub.h
+#ifndef HLS_STUB_H
+#define HLS_STUB_H
+#include <complex>
+#include <cmath>
+#include <queue>
+namespace hls {
+template<typename T>
+using x_complex = std::complex<T>;
+
+// ---------------------------------------------------------------------
+// Minimal hls::stream stub used for host compilation
+// ---------------------------------------------------------------------
+template<typename T>
+class stream {
+    std::queue<T> q;
+public:
+    inline bool empty() const { return q.empty(); }
+    inline void write(const T& v) { q.push(v); }
+    inline T read() { T v = q.front(); q.pop(); return v; }
+};
+
+inline float exp(float x) { return std::exp(x); }
+inline double exp(double x) { return std::exp(x); }
+
+inline float hypot(float x, float y) { return std::hypot(x, y); }
+inline double hypot(double x, double y) { return std::hypot(x, y); }
+
+inline void sincos(float x, float* s, float* c) { *s = std::sin(x); *c = std::cos(x); }
+inline void sincos(double x, double* s, double* c) { *s = std::sin(x); *c = std::cos(x); }
+}
+#endif

--- a/ComplexMultiplier/vitis-comp.json
+++ b/ComplexMultiplier/vitis-comp.json
@@ -1,0 +1,13 @@
+{
+  "name": "ComplexMultiplier",
+  "type": "HLS",
+  "configuration": {
+    "componentType": "HLS",
+    "configFiles": [
+      "hls_config.cfg"
+    ],
+    "work_dir": "ComplexMultiplier"
+  },
+  "useSysrootToolchain": false,
+  "template": "empty_hls_component"
+}


### PR DESCRIPTION
## Summary
- add `complex_mul` HLS IP for multiplying two complex numbers with AXI-Lite control interface
- include HLS configuration and metadata for Vitis 2025
- provide simple C++ testbench exercising the IP

## Testing
- `g++ ComplexMultiplier/complex_mul.cpp ComplexMultiplier/complex_mul_tb.cpp -std=c++17 -o ComplexMultiplier/test`
- `./ComplexMultiplier/test`


------
https://chatgpt.com/codex/tasks/task_e_6893b5879e148332a36e550f9cf7265e