### PR TITLE
Add DiffractionOnly ADI diffraction HLS component

### DIFF
--- a/DiffractionOnly/diffraction_only.cpp
+++ b/DiffractionOnly/diffraction_only.cpp
@@ -1,0 +1,165 @@
+#include "diffraction_only.h"
+
+// Physical constants
+static const data_t Lx = 45e-6f;
+static const data_t Ly = 45e-6f;
+static const data_t dx = Lx / N;
+static const data_t dy = Ly / N;
+static const data_t dz = 1e-4f;
+static const data_t k  = 7853981.6339f;
+static const data_t eps = 1e-12f;
+
+inline data_t abs_complex(complex_t z) {
+    return hls::hypot(z.real(), z.imag());
+}
+
+void compute_b_vector(
+    complex_t dp,
+    complex_t dp1,
+    complex_t dp2,
+    complex_t off,
+    complex_t x0[N],
+    complex_t b[N]
+) {
+    b[0] = dp1 * x0[0] + off * x0[1];
+    for (int i = 1; i < N - 1; i++) {
+        b[i] = off * x0[i-1] + dp * x0[i] + off * x0[i+1];
+    }
+    b[N-1] = off * x0[N-2] + dp2 * x0[N-1];
+}
+
+void thomas_solver(
+    complex_t dp,
+    complex_t dp1,
+    complex_t dp2,
+    complex_t off,
+    complex_t b[N],
+    complex_t x[N]
+) {
+    complex_t c_prime[N];
+#pragma HLS bind_storage variable=c_prime type=ram_2p impl=bram
+    complex_t d_prime[N];
+#pragma HLS bind_storage variable=d_prime type=ram_2p impl=bram
+
+    complex_t inv = complex_t(1,0) / dp1;
+    c_prime[0] = off * inv;
+    d_prime[0] = b[0] * inv;
+
+    for (int i = 1; i < N-1; i++) {
+        complex_t denom = dp - off * c_prime[i-1];
+        complex_t inv_d = complex_t(1,0) / denom;
+        c_prime[i] = off * inv_d;
+        d_prime[i] = (b[i] - off * d_prime[i-1]) * inv_d;
+    }
+
+    complex_t denom = dp2 - off * c_prime[N-2];
+    complex_t inv_d = complex_t(1,0) / denom;
+    d_prime[N-1] = (b[N-1] - off * d_prime[N-2]) * inv_d;
+
+    x[N-1] = d_prime[N-1];
+    for (int i = N-2; i >= 0; i--) {
+        x[i] = d_prime[i] - c_prime[i] * x[i+1];
+    }
+}
+
+void adi_x(complex_t in[N][N], complex_t out[N][N]) {
+    complex_t x0[N];
+    complex_t b[N];
+    complex_t x[N];
+#pragma HLS bind_storage variable=x0 type=ram_2p impl=bram
+#pragma HLS bind_storage variable=b  type=ram_2p impl=bram
+#pragma HLS bind_storage variable=x  type=ram_2p impl=bram
+    complex_t ung(0, dz / (4 * k * dx * dx));
+    for (int j = 0; j < N; j++) {
+        for (int i = 0; i < N; i++) {
+            x0[i] = in[i][j];
+        }
+        complex_t ratio_x0 = abs_complex(x0[1]) < eps ? complex_t(1,0) : x0[0] / x0[1];
+        complex_t ratio_xn = abs_complex(x0[N-2]) < eps ? complex_t(1,0) : x0[N-1] / x0[N-2];
+
+        complex_t dp1_B = -2.0f*ung + complex_t(1,0) + ung * ratio_x0;
+        complex_t dp2_B = -2.0f*ung + complex_t(1,0) + ung * ratio_xn;
+        complex_t dp_B  = -2.0f*ung + complex_t(1,0);
+        complex_t do_B  = ung;
+
+        compute_b_vector(dp_B, dp1_B, dp2_B, do_B, x0, b);
+
+        complex_t dp1_A = 2.0f*ung + complex_t(1,0) - ung * ratio_x0;
+        complex_t dp2_A = 2.0f*ung + complex_t(1,0) - ung * ratio_xn;
+        complex_t dp_A  = 2.0f*ung + complex_t(1,0);
+        complex_t do_A  = -ung;
+
+        thomas_solver(dp_A, dp1_A, dp2_A, do_A, b, x);
+
+        for (int i = 0; i < N; i++) {
+            out[i][j] = x[i];
+        }
+    }
+}
+
+void adi_y(complex_t in[N][N], complex_t out[N][N]) {
+    complex_t x0[N];
+    complex_t b[N];
+    complex_t x[N];
+#pragma HLS bind_storage variable=x0 type=ram_2p impl=bram
+#pragma HLS bind_storage variable=b  type=ram_2p impl=bram
+#pragma HLS bind_storage variable=x  type=ram_2p impl=bram
+    complex_t ung(0, dz / (4 * k * dy * dy));
+    for (int i = 0; i < N; i++) {
+        for (int j = 0; j < N; j++) {
+            x0[j] = in[i][j];
+        }
+        complex_t ratio_y0 = abs_complex(x0[1]) < eps ? complex_t(1,0) : x0[0] / x0[1];
+        complex_t ratio_yn = abs_complex(x0[N-2]) < eps ? complex_t(1,0) : x0[N-1] / x0[N-2];
+
+        complex_t dp1_B = -2.0f*ung + complex_t(1,0) + ung * ratio_y0;
+        complex_t dp2_B = -2.0f*ung + complex_t(1,0) + ung * ratio_yn;
+        complex_t dp_B  = -2.0f*ung + complex_t(1,0);
+        complex_t do_B  = ung;
+
+        compute_b_vector(dp_B, dp1_B, dp2_B, do_B, x0, b);
+
+        complex_t dp1_A = 2.0f*ung + complex_t(1,0) - ung * ratio_y0;
+        complex_t dp2_A = 2.0f*ung + complex_t(1,0) - ung * ratio_yn;
+        complex_t dp_A  = 2.0f*ung + complex_t(1,0);
+        complex_t do_A  = -ung;
+
+        thomas_solver(dp_A, dp1_A, dp2_A, do_A, b, x);
+
+        for (int j = 0; j < N; j++) {
+            out[i][j] = x[j];
+        }
+    }
+}
+
+void diffraction_only(
+    complex_t phi_in[N][N],
+    complex_t phi_out[N][N]
+) {
+#pragma HLS INTERFACE s_axilite port=return bundle=CTRL
+#pragma HLS INTERFACE m_axi   port=phi_in  offset=slave bundle=gmem depth=4096
+#pragma HLS INTERFACE mode=s_axilite port=phi_in  bundle=control
+#pragma HLS INTERFACE m_axi   port=phi_out offset=slave bundle=gmem depth=4096
+#pragma HLS INTERFACE mode=s_axilite port=phi_out bundle=control
+
+    complex_t phi[N][N];
+    complex_t tmp[N][N];
+#pragma HLS bind_storage variable=phi type=ram_2p impl=uram
+#pragma HLS bind_storage variable=tmp type=ram_2p impl=uram
+
+    for (int i = 0; i < N; i++) {
+        for (int j = 0; j < N; j++) {
+            phi[i][j] = phi_in[i][j];
+        }
+    }
+
+    adi_x(phi, tmp);
+    adi_y(tmp, phi);
+
+    for (int i = 0; i < N; i++) {
+        for (int j = 0; j < N; j++) {
+            phi_out[i][j] = phi[i][j];
+        }
+    }
+}
+

--- a/DiffractionOnly/diffraction_only.h
+++ b/DiffractionOnly/diffraction_only.h
@@ -1,0 +1,17 @@
+#ifndef DIFFRACTION_ONLY_H
+#define DIFFRACTION_ONLY_H
+
+#if __has_include(<hls_x_complex.h>)
+#  include <hls_x_complex.h>
+#else
+#  include "hls_stub.h"
+#endif
+
+const int N = 64;
+using data_t = float;
+using complex_t = hls::x_complex<data_t>;
+
+void diffraction_only(complex_t phi_in[N][N],
+                      complex_t phi_out[N][N]);
+
+#endif // DIFFRACTION_ONLY_H

--- a/DiffractionOnly/diffraction_tb.cpp
+++ b/DiffractionOnly/diffraction_tb.cpp
@@ -1,0 +1,13 @@
+#include "diffraction_only.h"
+
+int main() {
+    complex_t in[N][N];
+    complex_t out[N][N];
+    for (int i = 0; i < N; i++) {
+        for (int j = 0; j < N; j++) {
+            in[i][j] = complex_t(0, 0);
+        }
+    }
+    diffraction_only(in, out);
+    return 0;
+}

--- a/DiffractionOnly/hls_config.cfg
+++ b/DiffractionOnly/hls_config.cfg
@@ -1,0 +1,19 @@
+part=xck26-sfvc784-2LV-c
+
+[hls]
+flow_target=vivado
+package.output.format=ip_catalog
+package.output.syn=false
+clock=150Mhz
+clock_uncertainty=1%
+syn.top=diffraction_only
+syn.file=./hls_stub.h
+syn.file=./diffraction_only.cpp
+syn.file=./diffraction_only.h
+tb.file=./diffraction_tb.cpp
+csim.clean=1
+package.ip.vendor=fotonica109
+package.ip.version=1.0
+package.ip.description=operador de difraccion ADI
+package.ip.display_name=DiffractionOnly
+package.output.file=C:\Vws25\custom_ip_library\diffraction_only

--- a/DiffractionOnly/hls_stub.h
+++ b/DiffractionOnly/hls_stub.h
@@ -1,0 +1,32 @@
+// hls_stub.h
+#ifndef HLS_STUB_H
+#define HLS_STUB_H
+#include <complex>
+#include <cmath>
+#include <queue>
+namespace hls {
+template<typename T>
+using x_complex = std::complex<T>;
+
+// ---------------------------------------------------------------------
+// Minimal hls::stream stub used for host compilation
+// ---------------------------------------------------------------------
+template<typename T>
+class stream {
+    std::queue<T> q;
+public:
+    inline bool empty() const { return q.empty(); }
+    inline void write(const T& v) { q.push(v); }
+    inline T read() { T v = q.front(); q.pop(); return v; }
+};
+
+inline float exp(float x) { return std::exp(x); }
+inline double exp(double x) { return std::exp(x); }
+
+inline float hypot(float x, float y) { return std::hypot(x, y); }
+inline double hypot(double x, double y) { return std::hypot(x, y); }
+
+inline void sincos(float x, float* s, float* c) { *s = std::sin(x); *c = std::cos(x); }
+inline void sincos(double x, double* s, double* c) { *s = std::sin(x); *c = std::cos(x); }
+}
+#endif


### PR DESCRIPTION
## Summary
- Introduce `DiffractionOnly` HLS module performing ADI-based diffraction using URAM buffers
- Provide simple testbench and configuration targeting 150MHz clock with 1% uncertainty

## Testing
- `g++ -I DiffractionOnly DiffractionOnly/diffraction_tb.cpp DiffractionOnly/diffraction_only.cpp -o DiffractionOnly/diffraction_tb -std=c++17`
- `./DiffractionOnly/diffraction_tb`


------
https://chatgpt.com/codex/tasks/task_e_68953e773850833293d3ea3bef96767d