### PR TITLE
Add complex division HLS component

### DIFF
--- a/complex_division/compile_commands.json
+++ b/complex_division/compile_commands.json
@@ -1,1 +1,27 @@
-[]
+[
+  {
+    "directory": "C:\\DTI_work_space\\complex_division",
+    "arguments": [
+      "C:\\Xilinx\\2025.1\\Vitis\\vcxx\\libexec\\clang++.exe",
+      "--sysroot=C:\\Xilinx\\2025.1\\Vitis\\tps\\mingw\\10.0.0\\win64.o\\nt",
+      "-fhls",
+      "-hls-syn-headers-dir=C:\\Xilinx\\2025.1\\Vitis\\common\\technology\\autopilot",
+      "-fhlstoplevel=complex_div",
+      "-c",
+      "C:\\DTI_work_space\\complex_division\\.\\complex_div.cpp"
+    ],
+    "file": "C:\\DTI_work_space\\complex_division\\.\\complex_div.cpp"
+  },
+  {
+    "directory": "C:\\DTI_work_space\\complex_division",
+    "arguments": [
+      "C:\\Xilinx\\2025.1\\Vitis\\vcxx\\libexec\\clang++.exe",
+      "--sysroot=C:\\Xilinx\\2025.1\\Vitis\\tps\\mingw\\10.0.0\\win64.o\\nt",
+      "-fhls-tb",
+      "-hls-sim-headers-dir=C:\\Xilinx\\2025.1\\Vitis\\include",
+      "-c",
+      "C:\\DTI_work_space\\complex_division\\.\\complex_div_tb.cpp"
+    ],
+    "file": "C:\\DTI_work_space\\complex_division\\.\\complex_div_tb.cpp"
+  }
+]

--- a/complex_division/complex_div.cpp
+++ b/complex_division/complex_div.cpp
@@ -1,0 +1,10 @@
+#include "complex_div.h"
+
+void complex_div(complex_t a, complex_t b, complex_t &c) {
+#pragma HLS INTERFACE s_axilite port=a bundle=CTRL
+#pragma HLS INTERFACE s_axilite port=b bundle=CTRL
+#pragma HLS INTERFACE s_axilite port=c bundle=CTRL
+#pragma HLS INTERFACE s_axilite port=return bundle=CTRL
+
+    c = a / b;
+}

--- a/complex_division/complex_div.h
+++ b/complex_division/complex_div.h
@@ -1,0 +1,11 @@
+#ifndef COMPLEX_DIV_H
+#define COMPLEX_DIV_H
+
+#include <complex>
+
+using data_t = float;
+using complex_t = std::complex<data_t>;
+
+void complex_div(complex_t a, complex_t b, complex_t &c);
+
+#endif // COMPLEX_DIV_H

--- a/complex_division/complex_div_tb.cpp
+++ b/complex_division/complex_div_tb.cpp
@@ -1,0 +1,24 @@
+#include "complex_div.h"
+#include <iostream>
+#include <cmath>
+
+int main() {
+    complex_t a(4.0f, 2.0f);
+    complex_t b(1.0f, -3.0f);
+    complex_t c;
+
+    complex_div(a, b, c);
+
+    complex_t expected = a / b;
+    float err_r = expected.real() - c.real();
+    float err_i = expected.imag() - c.imag();
+    float rmse = std::sqrt((err_r * err_r + err_i * err_i) / 2.0f);
+
+    std::cout << "RMSE: " << rmse << "\n";
+    const float tol = 1e-5f;
+    if (rmse > tol) {
+        std::cerr << "RMS error too high\n";
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement complex_div using `std::complex<float>` with AXI Lite interfaces
- add trivial testbench computing RMS error of division
- update compile_commands for new component

## Testing
- `g++ complex_division/complex_div.cpp complex_division/complex_div_tb.cpp -std=c++17 -o complex_division/complex_div_test`
- `./complex_division/complex_div_test`

------
https://chatgpt.com/codex/tasks/task_e_689a557e65a88332b51aeb2ed856a808