### PR TITLE
docs: recommend std::complex

### DIFF
--- a/.context/contexto_hls1.txt
+++ b/.context/contexto_hls1.txt
@@ -37,3 +37,7 @@ Takeaway:
 * **Aggressive pipelining** yields high throughput but risks negative slack.
 * **Relaxation** (higher II or no pipeline) trades performance for timing safety.
 * **Partitioning arrays** and **function-level isolation** are the strongest levers to clear critical paths before tuning pipelining.
+
+8. Uso de std::complex
+   • La documentación de AMD Xilinx Vitis HLS 2025.1 recomienda `std::complex` en lugar de `hls::complex`.
+   • `std::complex` es parte del estándar de C++ y ofrece más compatibilidad y operadores, mientras que `hls::complex` queda para compatibilidad heredada.

--- a/.context/guidelines.md
+++ b/.context/guidelines.md
@@ -6,3 +6,8 @@ ejemplo la estructura de Custom_Thomas_Solver_v1.
 
 esto facilita la declaraciones en hls_config.cfg
 
+# Librería complex
+
+- Usar siempre `std::complex` en lugar de `hls::complex`.
+- `std::complex` es parte del estándar de C++ y tiene mejor compatibilidad; `hls::complex` queda solo por soporte heredado según AMD Xilinx Vitis HLS 2025.1.
+


### PR DESCRIPTION
## Summary
- Add short note recommending `std::complex` over `hls::complex`.
- Update guidelines to always use `std::complex` for complex numbers.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a562aca90833290afb785f41c18f3