### PR TITLE
Add complex array division HLS component

### DIFF
--- a/c_array_cdiv/c_array_cdiv.cpp
+++ b/c_array_cdiv/c_array_cdiv.cpp
@@ -1,0 +1,59 @@
+#include "c_array_cdiv.h"
+
+static complex_t complex_div(const complex_t &a, const complex_t &b) {
+    data_t br = b.real();
+    data_t bi = b.imag();
+    data_t denom = br*br + bi*bi;
+    data_t inv   = (data_t)1.0f / denom;
+    complex_t conj_b(br, -bi);
+    complex_t num = a * conj_b;
+    return complex_t(num.real() * inv, num.imag() * inv);
+}
+
+static void array_to_stream(const complex_t in[N], hls::stream<complex_t> &s) {
+    for (int i = 0; i < N; i++) {
+#pragma HLS PIPELINE II=1
+        s.write(in[i]);
+    }
+}
+
+static void stream_div(hls::stream<complex_t> &in_s,
+                       hls::stream<complex_t> &out_s,
+                       const complex_t &div) {
+    for (int i = 0; i < N; i++) {
+#pragma HLS PIPELINE II=1
+        complex_t v = in_s.read();
+        out_s.write(complex_div(v, div));
+    }
+}
+
+static void stream_to_array(hls::stream<complex_t> &s, complex_t out[N]) {
+    for (int i = 0; i < N; i++) {
+#pragma HLS PIPELINE II=1
+        out[i] = s.read();
+    }
+}
+
+void c_array_cdiv(const complex_t in[N],
+                  complex_t out[N],
+                  data_t div_real,
+                  data_t div_imag) {
+#pragma HLS INTERFACE s_axilite port=return bundle=control
+#pragma HLS INTERFACE m_axi     port=in  offset=slave bundle=gmem depth=64
+#pragma HLS INTERFACE s_axilite port=in  bundle=control
+#pragma HLS INTERFACE m_axi     port=out offset=slave bundle=gmem depth=64
+#pragma HLS INTERFACE s_axilite port=out bundle=control
+#pragma HLS INTERFACE s_axilite port=div_real bundle=control
+#pragma HLS INTERFACE s_axilite port=div_imag bundle=control
+
+    hls::stream<complex_t> s_in;
+    hls::stream<complex_t> s_out;
+#pragma HLS STREAM variable=s_in depth=64
+#pragma HLS STREAM variable=s_out depth=64
+
+    complex_t div(div_real, div_imag);
+
+    array_to_stream(in, s_in);
+    stream_div(s_in, s_out, div);
+    stream_to_array(s_out, out);
+}

--- a/c_array_cdiv/c_array_cdiv.h
+++ b/c_array_cdiv/c_array_cdiv.h
@@ -1,0 +1,20 @@
+#ifndef C_ARRAY_CDIV_H
+#define C_ARRAY_CDIV_H
+
+#if __has_include(<hls_x_complex.h>)
+#  include <hls_x_complex.h>
+#  include <hls_stream.h>
+#else
+#  include "hls_stub.h"
+#endif
+
+const int N = 64;
+using data_t    = float;
+using complex_t = hls::x_complex<data_t>;
+
+void c_array_cdiv(const complex_t in[N],
+                  complex_t out[N],
+                  data_t div_real,
+                  data_t div_imag);
+
+#endif // C_ARRAY_CDIV_H

--- a/c_array_cdiv/compile_commands.json
+++ b/c_array_cdiv/compile_commands.json
@@ -1,1 +1,15 @@
-[]
+[
+  {
+    "directory": "C:\\DTI_work_space\\c_array_cdiv",
+    "arguments": [
+      "C:\\Xilinx\\2025.1\\Vitis\\vcxx\\libexec\\clang++.exe",
+      "--sysroot=C:\\Xilinx\\2025.1\\Vitis\\tps\\mingw\\10.0.0\\win64.o\\nt",
+      "-fhls",
+      "-hls-syn-headers-dir=C:\\Xilinx\\2025.1\\Vitis\\common\\technology\\autopilot",
+      "-fhlstoplevel=c_array_cdiv",
+      "-c",
+      "C:\\DTI_work_space\\c_array_cdiv\\.\\c_array_cdiv.cpp"
+    ],
+    "file": "C:\\DTI_work_space\\c_array_cdiv\\.\\c_array_cdiv.cpp"
+  }
+]

--- a/c_array_cdiv/hls_stub.h
+++ b/c_array_cdiv/hls_stub.h
@@ -1,0 +1,32 @@
+// hls_stub.h
+#ifndef HLS_STUB_H
+#define HLS_STUB_H
+#include <complex>
+#include <cmath>
+#include <queue>
+namespace hls {
+template<typename T>
+using x_complex = std::complex<T>;
+
+// ---------------------------------------------------------------------
+// Minimal hls::stream stub used for host compilation
+// ---------------------------------------------------------------------
+template<typename T>
+class stream {
+    std::queue<T> q;
+public:
+    inline bool empty() const { return q.empty(); }
+    inline void write(const T& v) { q.push(v); }
+    inline T read() { T v = q.front(); q.pop(); return v; }
+};
+
+inline float exp(float x) { return std::exp(x); }
+inline double exp(double x) { return std::exp(x); }
+
+inline float hypot(float x, float y) { return std::hypot(x, y); }
+inline double hypot(double x, double y) { return std::hypot(x, y); }
+
+inline void sincos(float x, float* s, float* c) { *s = std::sin(x); *c = std::cos(x); }
+inline void sincos(double x, double* s, double* c) { *s = std::sin(x); *c = std::cos(x); }
+}
+#endif


### PR DESCRIPTION
## Summary
- Implement `c_array_cdiv` to divide 64 complex values by a complex scalar using `hls::stream`
- Expose AXI4 memory interfaces with corresponding AXI-Lite control ports for input, output, and divisor
- Provide local `hls_stub.h` and update build commands

## Testing
- `g++ -std=c++17 -I c_array_cdiv -c c_array_cdiv/c_array_cdiv.cpp`


------
https://chatgpt.com/codex/tasks/task_e_689a57a415b48332a201d7026317ecb0