### PR TITLE
Add buffer overlay copy kernel

### DIFF
--- a/BufferOverlay/copy_kernel.cpp
+++ b/BufferOverlay/copy_kernel.cpp
@@ -1,0 +1,14 @@
+#include "copy_kernel.h"
+
+extern "C" void copy_kernel(const complex_t* in, complex_t* out) {
+#pragma HLS INTERFACE s_axilite port=return bundle=control
+#pragma HLS INTERFACE m_axi port=in  bundle=gmem depth=4096
+#pragma HLS INTERFACE m_axi port=out bundle=gmem depth=4096
+#pragma HLS INTERFACE s_axilite port=in  bundle=control
+#pragma HLS INTERFACE s_axilite port=out bundle=control
+
+  for (int idx = 0; idx < TOTAL; ++idx) {
+#pragma HLS PIPELINE II=1
+    out[idx] = in[idx];
+  }
+}

--- a/BufferOverlay/copy_kernel.h
+++ b/BufferOverlay/copy_kernel.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <complex>
+#ifndef N
+#define N 64
+#endif
+static constexpr int TOTAL = N * N;
+using complex_t = std::complex<float>;
+extern "C" void copy_kernel(const complex_t* in, complex_t* out);

--- a/BufferOverlay/copy_tb.cpp
+++ b/BufferOverlay/copy_tb.cpp
@@ -1,0 +1,23 @@
+#include "copy_kernel.h"
+#include <iostream>
+
+int main() {
+  complex_t in[TOTAL];
+  complex_t out[TOTAL];
+
+  for (int i = 0; i < TOTAL; ++i) {
+    in[i] = complex_t((float)i, (float)(-i));
+    out[i] = complex_t(0.0f, 0.0f);
+  }
+
+  copy_kernel(in, out);
+
+  for (int i = 0; i < TOTAL; ++i) {
+    if (out[i] != in[i]) {
+      std::cerr << "Mismatch at index " << i << "\n";
+      return 1;
+    }
+  }
+  std::cout << "Copy kernel test passed" << std::endl;
+  return 0;
+}


### PR DESCRIPTION
## Summary
- Add BufferOverlay component with a copy_kernel that mirrors a 64x64 complex matrix through AXI interfaces
- Include basic testbench to validate copy kernel behavior

## Testing
- `g++ -std=c++17 BufferOverlay/copy_kernel.cpp BufferOverlay/copy_tb.cpp -o BufferOverlay/copy_tb`
- `./BufferOverlay/copy_tb`

------
https://chatgpt.com/codex/tasks/task_e_68aceca547e8833293780f1caa522aab