### PR TITLE
Add loss parameters to ADI diffraction kernel

### DIFF
--- a/Diff_Losses_Nsteps/diff_losses.h
+++ b/Diff_Losses_Nsteps/diff_losses.h
@@ -35,5 +35,7 @@ static bool      c_near_zero(const complex_t &z, data_t eps2);
 void diff_losses(
     const complex_t phi_in[N][N],
           complex_t phi_out[N][N],
-    int steps
+    int steps,
+    data_t alpha,
+    data_t beta
 );

--- a/Diff_Losses_Nsteps/diff_losses_tb.cpp
+++ b/Diff_Losses_Nsteps/diff_losses_tb.cpp
@@ -26,7 +26,9 @@ int main() {
     read_matrix("./phi_in.dat", in);
     read_matrix("./golden.dat", golden);
 
-    diff_losses(in, out, 361);
+    const data_t alpha = 0.0f;
+    const data_t beta  = 0.0f;
+    diff_losses(in, out, 361, alpha, beta);
 
     double err = 0.0;
     for (int i = 0; i < N; i++) {


### PR DESCRIPTION
## Summary
- Accept linear and two-photon loss coefficients in `diff_losses` kernel
- Implement midpoint loss operator with Strang splitting
- Update test bench/host to pass `alpha` and `beta`

## Testing
- `g++ diff_losses.cpp diff_losses_tb.cpp -std=c++17 -I. -o test && ./test >/tmp/test_output.log && tail -n 20 /tmp/test_output.log`


------
https://chatgpt.com/codex/tasks/task_e_68c0c6f01b8c8332aa534fadd4c6a5e5